### PR TITLE
Add log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ You can use this action to delete a preview environment in Okteto as part of you
 
 **Required**  The name of the Okteto preview environment to delete.
 
+### `log-level`
+
+Log level used. Supported values are: `debug`, `info`, `warn`, `error`. (defaults to warn)
+
 ## Example usage
 
 This example runs the context action and then deletes a preview environment.

--- a/action.yml
+++ b/action.yml
@@ -4,11 +4,15 @@ inputs:
   name: 
     description: "The name of the preview environment to delete"
     required: true
+  log-level:
+    description: "Log level string. Valid options are debug, info, warn, error"
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"
   args:
     - ${{ inputs.name }}
+    - ${{ inputs.log-level }}
 branding:
   color: 'green'
   icon: 'grid'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ if [ ! -z "$log_level" ]; then
   if [ "$log_level" = "debug" ] || [ "$log_level" = "info" ] || [ "$log_level" = "warn" ] || [ "$log_level" = "error" ] ; then
     log_level="--log-level ${log_level}"
   else
-    echo "log-level supported: debug, info, warn, error"
+    echo "unsupported log-level ${log_level}, supported options are: debug, info, warn, error"
     exit 1
   fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,5 +13,22 @@ if [ ! -z "$OKTETO_CA_CERT" ]; then
    update-ca-certificates
 fi
 
-echo running: okteto preview destroy $name
-okteto preview destroy $name
+log_level=$2
+if [ ! -z "$log_level" ]; then
+  if [ "$log_level" = "debug" ] || [ "$log_level" = "info" ] || [ "$log_level" = "warn" ] || [ "$log_level" = "error" ] ; then
+    log_level="--log-level ${log_level}"
+  else
+    echo "log-level supported: debug, info, warn, error"
+    exit 1
+  fi
+fi
+
+# https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging
+# https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+if [ "${RUNNER_DEBUG}" = "1" ]; then
+  log_level="--log-level debug"
+fi
+
+
+echo running: okteto preview destroy $name $log_level
+okteto preview destroy $name $log_level


### PR DESCRIPTION
Resolves https://okteto.atlassian.net/browse/DEV-320

As done for `deploy-preview` this PR adds the input of log-level to the action in order to enable debug logging or any other level the user wants to use on the runs.

Tested running the pipeline using the last commit 
https://github.com/teresaromero/go-getting-started/actions/workflows/test-actions.yml